### PR TITLE
#126 fix - dhs double zipping 

### DIFF
--- a/R/dhs.R
+++ b/R/dhs.R
@@ -173,16 +173,16 @@ lodown_dhs <-
 
 			# some zipped files contained zipped subfiles
 
-			if( any( st <- grepl( "\\.zip$" , unzipped_files , ignore.case = TRUE ) ) ){
+			if( any( stz <- grepl( "\\.zip$" , unzipped_files , ignore.case = TRUE ) ) ){
 
 			  # this means multiple .rds files
 			  rds_name <- gsub( "\\.zip" , ".rds" , grep( "\\.zip$" , unzipped_files , ignore.case = TRUE, value = TRUE) , ignore.case = TRUE)
 
 			  # and adding new rows to the catalog
-			  catalog <- rbind( catalog , rep( catalog[ i , ], sum( st ) - 1 ) )
+			  catalog <- rbind( catalog , rep( catalog[ i , ], sum( stz ) - 1 ) )
 
 			  # and changing the output_filename in the new rows
-			  catalog$output_filename[ ( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog ) ] <-  unzipped_files[ !grepl( catalog[ i , 'output_filename' ], unzipped_files, ignore.case = TRUE ) ]
+			  catalog$output_filename[ ( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog ) ] <-  unzipped_files[ !grepl( catalog[ i , 'output_filename' ], unzipped_files, ignore.case = TRUE ) ]
 
 
 			} else {
@@ -212,7 +212,8 @@ lodown_dhs <-
 				# convert all column names to lowercase
 				names( x ) <- tolower( names( x ) )
 
-				catalog[ catalog$output_filename ==  unzipped_files[ st ] [ j ], 'case_count' ] <- nrow( x )
+				# note nrows of extracted dataset
+				catalog[ catalog$output_filename ==  gsub("\\FL.DTA", "DT.zip", unzipped_files[st][j]), 'case_count' ] <- nrow( x )
 
 				# save the file on the local disk, within the appropriate country-survey filepath
 				saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
@@ -236,7 +237,8 @@ lodown_dhs <-
 				    # convert all column names to lowercase
 				    names( x ) <- tolower( names( x ) )
 
-				    catalog[ catalog$output_filename ==  unzipped_files[ st ] [ j ], 'case_count' ] <- nrow( x )
+				    # note nrows of extracted dataset
+				    catalog[ catalog$output_filename ==  gsub("\\FL.DTA", "DT.zip", unzipped_files[st][j]), 'case_count' ]
 
 				    # save the file on the local disk, within the appropriate country-survey filepath
 				    saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
@@ -249,7 +251,7 @@ lodown_dhs <-
 			suppressWarnings( file.remove( unzipped_files ) )
 
 			for ( j in 1 : sum( st ) ){
-			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
+			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
 			}
 		}
 

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -213,7 +213,7 @@ lodown_dhs <-
 				names( x ) <- tolower( names( x ) )
 
 				# note nrows of extracted dataset
-				catalog[ catalog$output_filename ==  gsub("\\FL.DTA", "DT.zip", unzipped_files[st][j]), 'case_count' ] <- nrow( x )
+				catalog[ grepl( gsub( "\\FL.DTA" , "DT.zip" , unzipped_files[st][j]), catalog$output_filename, ignore.case = TRUE ), 'case_count' ] <- nrow(x)
 
 				# save the file on the local disk, within the appropriate country-survey filepath
 				saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
@@ -238,7 +238,7 @@ lodown_dhs <-
 				    names( x ) <- tolower( names( x ) )
 
 				    # note nrows of extracted dataset
-				    catalog[ catalog$output_filename ==  gsub("\\FL.DTA", "DT.zip", unzipped_files[st][j]), 'case_count' ]
+				    catalog[ grepl( gsub( "\\FL.SAV" , "DT.zip" , unzipped_files[st][j]), catalog$output_filename, ignore.case = TRUE ), 'case_count' ] <- nrow(x)
 
 				    # save the file on the local disk, within the appropriate country-survey filepath
 				    saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
@@ -250,8 +250,8 @@ lodown_dhs <-
 			# delete the temporary files
 			suppressWarnings( file.remove( unzipped_files ) )
 
-			for ( j in 1 : max(1, sum( stz )) ){
-			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
+			for ( j in 1 : max( 1, sum( stz ) ) ) {
+			  cat( paste0( "\n\n" , data_name , " catalog entry " , c( i , ( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog ) ) [ j ] , " of " , nrow( catalog ) , " stored at '" , catalog[ c( i , ( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog ) ) [ j ]  , 'output_filename' ] , "'\r\n\n" ) )
 			}
 		}
 

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -250,7 +250,7 @@ lodown_dhs <-
 			# delete the temporary files
 			suppressWarnings( file.remove( unzipped_files ) )
 
-			for ( j in 1 : sum( st ) ){
+			for ( j in 1 : sum( stz ) ){
 			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
 			}
 		}

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -2,32 +2,32 @@ get_catalog_dhs <-
 	function( data_name = "dhs" , output_dir , ... ){
 
 		catalog <- NULL
-		
+
 		tf <- tempfile()
-		
+
 		if( !( 'your_email' %in% names(list(...)) ) ) stop( "`your_email` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_email <- list(...)[["your_email"]]
 
 		if( !( 'your_password' %in% names(list(...)) ) ) stop( "`your_password` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_password <- list(...)[["your_password"]]
 
 		if( !( 'your_project' %in% names(list(...)) ) ) stop( "`your_project` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_project <- list(...)[["your_project"]]
 
 		values <- dhs_authenticate( your_email , your_password , your_project )
-		
+
 		project.number <- values$proj_id
-		
+
 		# re-access the download-datasets page
 		z <- httr::POST( "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm" , body = list( proj_id = project.number ) )
 
 		# write the information from the `countries` page to a local file
 		writeBin( z$content , tf )
 
-		# load the text 
+		# load the text
 		y <- readLines( tf , warn = FALSE )
 
 		# figure out the country lines
@@ -44,16 +44,16 @@ get_catalog_dhs <-
 			# extract the current country number..
 			this.number <- country.numbers[ j ]
 			# ..and current country name
-			this.name <- country.names[ j ] 
+			this.name <- country.names[ j ]
 
 			# create the country directory on the local disk
 			# dir.create( paste0( "./" , this.name ) )
 
 
-		
+
 			# create a website key pointing the specific country
-			values <- 
-				list( 
+			values <-
+				list(
 					proj_id = project.number ,
 					Apr_Ctry_list_id = this.number ,
 					submitted = 2 ,
@@ -64,14 +64,14 @@ get_catalog_dhs <-
 			# re-access the download data page
 			# using the new country-specific key
 			z <- httr::POST( "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm" , body = values )
-				
+
 			# pull all links
 			link.urls <- XML::xpathSApply( XML::htmlParse( httr::content( z ) ) , "//a" , XML::xmlGetAttr , "href" )
 
 			# extract all links containing the current country's name
 			valid.surveys <- grep( "?flag=1" , link.urls )
 			link.urls <- unlist( link.urls [ valid.surveys ] )
-			
+
 			# loop through each available data set within the country #
 			for ( this.link in link.urls ){
 
@@ -79,7 +79,7 @@ get_catalog_dhs <-
 				z <- httr::GET( paste0( "https://dhsprogram.com" , this.link ) )
 
 				writeBin( z$content , tf )
-				
+
 				# read the table from each country page, remove the country name, and remove extraneous characters
 				this.title <- gsub( ": |," , "" , gsub( this.name , "" , gsub( '(.*)surveyTitle\">(.*)<(.*)' , "\\2" , grep( 'surveyTitle\">' , readLines( tf , warn = FALSE ) , value = TRUE ) ) ) )
 
@@ -94,9 +94,9 @@ get_catalog_dhs <-
 
 				# directory path
 				# this_dir <- paste0( "./" , this.name , "/" , this.title )
-				
+
 				for( file.url in unlist( data.link ) ){
-					
+
 					this_catalog <-
 						data.frame(
 							country = this.name ,
@@ -106,16 +106,16 @@ get_catalog_dhs <-
 							output_filename = paste0( output_dir , "/" , this.name , "/" , this.title , "/" , gsub( "(.*)Filename=(.*)\\.(ZIP|zip)(.*)" , "\\2.zip" , file.url ) ) ,
 							full_url = paste0( "https://dhsprogram.com" , file.url ) ,
 							stringsAsFactors = FALSE
-						)		
-					
+						)
+
 					catalog <- rbind( catalog , this_catalog )
-				
+
 				}
 			}
 		}
 
 		catalog$output_folder <- gsub( "\\.zip" , "" , catalog$output_filename , ignore.case = TRUE )
-		
+
 		unique( catalog )
 
 	}
@@ -127,30 +127,30 @@ lodown_dhs <-
 		on.exit( print( catalog ) )
 
 		if( !( 'your_email' %in% names(list(...)) ) ) stop( "`your_email` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_email <- list(...)[["your_email"]]
 
 		if( !( 'your_password' %in% names(list(...)) ) ) stop( "`your_password` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_password <- list(...)[["your_password"]]
 
 		if( !( 'your_project' %in% names(list(...)) ) ) stop( "`your_project` parameter must be specified.  create an account at https://dhsprogram.com/data/new-user-registration.cfm" )
-		
+
 		your_project <- list(...)[["your_project"]]
 
 		values <- dhs_authenticate( your_email , your_password , your_project )
 
 		project.number <- values$proj_id
-		
+
 		# re-access the download-datasets page
 		z <- httr::POST( "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm" , body = list( proj_id = project.number ) )
 
 		for ( i in seq_len( nrow( catalog ) ) ){
 
 			# create a website key pointing the specific country
-			values <- 
-				list( 
-					proj_id = catalog[ i , "proj_id" ] , 
+			values <-
+				list(
+					proj_id = catalog[ i , "proj_id" ] ,
 					Apr_Ctry_list_id = catalog[ i , "Apr_Ctry_list_id" ] ,
 					submitted = 2 ,
 					action = "View Surveys" ,
@@ -160,75 +160,88 @@ lodown_dhs <-
 			# re-access the download data page
 			# using the new country-specific key
 			z <- httr::POST( "https://dhsprogram.com/data/dataset_admin/download-datasets.cfm" , body = values )
-		
+
 			# download the actual microdata file directly to disk
 			# don't read it into memory.  save it as `tf` immediately (RAM-free)
 			cachaca( catalog[ i , 'full_url' ] , destfile = catalog[ i , 'output_filename' ] , FUN = httr::GET , filesize_fun = 'unzip_verify' , httr::write_disk( catalog[ i , 'output_filename' ] , overwrite = TRUE ) , httr::progress() )
-			
+
 			# make sure the file-specific folder exists
 			# dir.create( gsub( "\\.zip" , "" , zfn , ignore.case = TRUE ) , showWarnings = FALSE )
-			
+
 			# unzip the contents of the zipped file
 			unzipped_files <- unzip_warn_fail( catalog[ i , 'output_filename' ] , exdir = catalog[ i , 'output_folder' ] )
 
 			# some zipped files contained zipped subfiles
+
+			if( any( st <- grepl( "\\.zip$" , unzipped_files , ignore.case = TRUE ) ) ){
+
+			  # this means multiple .rds files
+			  rds_name <- gsub( "\\.zip" , ".rds" , grep( "\\.zip$" , unzipped_files , ignore.case = TRUE, value = TRUE) , ignore.case = TRUE)
+
+			  # and adding new rows to the catalog
+			  catalog <- rbind( catalog , rep( catalog[ i , ], sum( st ) - 1 ) )
+
+			  # and changing the output_filename in the new rows
+			  catalog$output_filename[ ( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog ) ] <- unzipped_files[ unzipped_files != catalog[ i , 'output_filename' ] ]
+
+			} else {
+			  # figure out the correct location for the single rds file
+			  rds_name <- gsub( "\\.zip" , ".rds" , catalog[ i , 'output_filename' ] , ignore.case = TRUE )
+			  }
+
+			# extract the zipped subfiles
 			for( this_zip in grep( "\\.zip$" , unzipped_files , ignore.case = TRUE , value = TRUE ) ){
-			
+
 				unzipped_files <- unzipped_files[ unzipped_files != this_zip ]
-				
+
 				unzipped_files <- c( unzipped_files , unzip_warn_fail( this_zip , exdir = catalog[ i , 'output_folder' ] ) )
-				
+
 			}
-			
-			# remove files with the same names
-			unzipped_files <- unzipped_files[ !duplicated( tolower( unzipped_files ) ) ]
-			
-			# figure out the correct location for the rds
-			rds_name <- gsub( "\\.zip" , ".rds" , catalog[ i , 'output_filename' ] , ignore.case = TRUE )
-			
+
 			# and now, if there's a stata file, import it!
 			if ( any( st <- grepl( "\\.dta$" , tolower( unzipped_files ) ) ) ){
-				
+
 				# remove any prior `x` tables ; clear up RAM
 				suppressWarnings( rm( x ) )
-				
+
+			  for ( j in 1 : sum( st ) ){
 				# load the current stata file into working memory
-				x <- data.frame( haven::read_dta( unzipped_files[ which( st ) ] ) )
-			
+				x <- data.frame( haven::read_dta( unzipped_files[ st ] [ j ] ) )
+
 				# convert all column names to lowercase
 				names( x ) <- tolower( names( x ) )
 
-				catalog[ i , 'case_count' ] <- nrow( x )
-				
+				catalog[ catalog$output_filename ==  unzipped_files[ st ] [ j ], 'case_count' ] <- nrow( x )
+
 				# save the file on the local disk, within the appropriate country-survey filepath
-				saveRDS( x , file = rds_name ) ; rm( x ) ; gc()
-				
+				saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
+			  }
 			}
 
 			# if a file has not been saved as an rds yet,
 			# look for an spss file as well.  this way, stata always takes priority.
 			if ( !file.exists( rds_name ) ){
-			
+
 				# if there's any spss file, import it!
 				if ( any( st <- grepl( "\\.sav$" , tolower( unzipped_files ) ) ) ){
-					
+
 					# remove any prior `x` tables ; clear up RAM
 					suppressWarnings( rm( x ) )
-					
+
 					# load the current stata file into working memory
 					x <- data.frame( haven::read_spss( unzipped_files[ which( st ) ] ) )
-		
+
 					# convert all column names to lowercase
 					names( x ) <- tolower( names( x ) )
-					
+
 					catalog[ i , 'case_count' ] <- nrow( x )
 
 					# save the file on the local disk, within the appropriate country-survey filepath
 					saveRDS( x , file = rds_name ) ; rm( x ) ; gc()
-					
+
 				}
 			}
-		
+
 			# delete the temporary files
 			suppressWarnings( file.remove( unzipped_files ) )
 
@@ -237,12 +250,12 @@ lodown_dhs <-
 		}
 
 		on.exit()
-		
+
 		catalog
 
 	}
-	
-	
+
+
 
 
 dhs_authenticate <-
@@ -259,9 +272,9 @@ dhs_authenticate <-
 
 
 		# set the username and password
-		values <- 
-			list( 
-				UserName = your_email , 
+		values <-
+			list(
+				UserName = your_email ,
 				UserPass = your_password ,
 				Submitted = 1 ,
 				UserType = 2
@@ -277,24 +290,23 @@ dhs_authenticate <-
 		# write the information from the `projects` page to a local file
 		writeBin( z$content , tf )
 
-		# load the text 
+		# load the text
 		y <- readLines( tf , warn = FALSE )
 
 		# figure out the project number
 		project.line <- unique( y[ grep( paste0( "option value(.*)" , your_project ) , y ) ] )
 
 		# confirm only one project
-		stopifnot( length( project.line ) == 1 ) 
+		stopifnot( length( project.line ) == 1 )
 
 		# extract the project number from the line above
 		project.number <- gsub( "(.*)<option value=\"([0-9]*)\">(.*)" , "\\2" , project.line )
 
 		# log in again, but specifically with the project number
-		list( 
-			UserName = your_email , 
+		list(
+			UserName = your_email ,
 			UserPass = your_password ,
 			proj_id = project.number
 		)
-	
+
 	}
-	

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -221,7 +221,7 @@ lodown_dhs <-
 
 			# if a file has not been saved as an rds yet,
 			# look for an spss file as well.  this way, stata always takes priority.
-			if ( !file.exists( rds_name ) ){
+			if (!any( !file.exists( rds_name ) ) ){
 
 				# if there's any spss file, import it!
 				if ( any( st <- grepl( "\\.sav$" , tolower( unzipped_files ) ) ) ){
@@ -229,16 +229,18 @@ lodown_dhs <-
 					# remove any prior `x` tables ; clear up RAM
 					suppressWarnings( rm( x ) )
 
-					# load the current stata file into working memory
-					x <- data.frame( haven::read_spss( unzipped_files[ which( st ) ] ) )
+				  for ( j in 1 : sum( st ) ){
+				    # load the current spss file into working memory
+				    x <- data.frame( haven::read_spss( unzipped_files[ st ] [ j ] ) )
 
-					# convert all column names to lowercase
-					names( x ) <- tolower( names( x ) )
+				    # convert all column names to lowercase
+				    names( x ) <- tolower( names( x ) )
 
-					catalog[ i , 'case_count' ] <- nrow( x )
+				    catalog[ catalog$output_filename ==  unzipped_files[ st ] [ j ], 'case_count' ] <- nrow( x )
 
-					# save the file on the local disk, within the appropriate country-survey filepath
-					saveRDS( x , file = rds_name ) ; rm( x ) ; gc()
+				    # save the file on the local disk, within the appropriate country-survey filepath
+				    saveRDS( x , file = rds_name[ j ] ) ; rm( x ) ; gc()
+				  }
 
 				}
 			}

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -182,7 +182,8 @@ lodown_dhs <-
 			  catalog <- rbind( catalog , rep( catalog[ i , ], sum( st ) - 1 ) )
 
 			  # and changing the output_filename in the new rows
-			  catalog$output_filename[ ( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog ) ] <- unzipped_files[ unzipped_files != catalog[ i , 'output_filename' ] ]
+			  catalog$output_filename[ ( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog ) ] <-  unzipped_files[ !grepl( catalog[ i , 'output_filename' ], unzipped_files, ignore.case = TRUE ) ]
+
 
 			} else {
 			  # figure out the correct location for the single rds file
@@ -245,8 +246,9 @@ lodown_dhs <-
 			# delete the temporary files
 			suppressWarnings( file.remove( unzipped_files ) )
 
-			cat( paste0( "\n\n" , data_name , " catalog entry " , i , " of " , nrow( catalog ) , " stored at '" , catalog[ i , 'output_filename' ] , "'\r\n\n" ) )
-
+			for ( j in 1 : sum( st ) ){
+			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( st ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
+			}
 		}
 
 		on.exit()

--- a/R/dhs.R
+++ b/R/dhs.R
@@ -250,7 +250,7 @@ lodown_dhs <-
 			# delete the temporary files
 			suppressWarnings( file.remove( unzipped_files ) )
 
-			for ( j in 1 : sum( stz ) ){
+			for ( j in 1 : max(1, sum( stz )) ){
 			  cat( paste0( "\n\n" , data_name , " catalog entry " , c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j] , " of " , nrow( catalog ) , " stored at '" , catalog[ c(i,( nrow( catalog ) - sum( stz ) + 2 ) : nrow( catalog )) [j]  , 'output_filename' ] , "'\r\n\n" ) )
 			}
 		}


### PR DESCRIPTION
OK, here it is. This extracts all .zip files if sub zipfiles exist. It also adds a row to the catalog, and even gives a semi-correct message at the end of each file extraction - the only issue there is that you cannot know in advance if you have one of these files in your catalog, so it is impossible to always correctly know how many entries there will be in total until the end. 

Other than that it's great. :)
Mind you, this still won't work on Windows. I think that could be solved actually just by extracting into a different folder than the download folder. But I can't test it now, but can check back in a few weeks when i get back to my work computer. 

And thanks for this opportunity, I learned a tonne!
(sorry about the spacing, I have no idea what is going on there!)

