### PR TITLE
Try latin1 and windows-1252 in remove_uf

### DIFF
--- a/R/pnad.R
+++ b/R/pnad.R
@@ -280,10 +280,10 @@ pnad_remove_uf <-
 		# read the SAS import file into R
 		##does not work on linux sascon <- file( sasfile , "rb" , blocking = FALSE , encoding = "windows-1252" )
 		sas_lines <- readLines( sasfile , encoding="windows-1252")
-		sas_lines <- iconv( sas_lines , "" , "ASCII//TRANSLIT" )
+		sas_lines <- iconv( sas_lines , "windows-1252" , "ASCII//TRANSLIT" )
 		if (is.na(sas_lines[1])) {
 			sas_lines <- readLines( sasfile , encoding="latin1")
-			sas_lines <- iconv( sas_lines , "" , "ASCII//TRANSLIT" )
+			sas_lines <- iconv( sas_lines , "latin1" , "ASCII//TRANSLIT" )
 			}
 
 		##close( sascon )


### PR DESCRIPTION
Code breaks in linux due to encoding reasons. This patch fixes that, by: a) trying both windows-1252 and latin1; b) supplying origin encoding in the iconv call.