### PR TITLE
Get PME running

### DIFF
--- a/R/pme.R
+++ b/R/pme.R
@@ -84,7 +84,7 @@ lodown_pme <-
 
 		tf <- tempfile()
 
-		cachaca( "ftp://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Microdados/documentacao/Documentacao.zip" , tf )
+		cachaca( "ftp://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Microdados/documentacao/Documentacao.zip" , tf, filesize_fun = 'unzip_verify' )
 
 		unzipped_files <- unzip_warn_fail( tf , exdir = unique( np_dirname( catalog$output_filename ) )  )
 
@@ -94,13 +94,16 @@ lodown_pme <-
 		for ( i in seq_len( nrow( catalog ) ) ){
 
 			# download the file
-			cachaca( catalog[ i , "full_url" ] , tf , mode = 'wb' )
+			cachaca( catalog[ i , "full_url" ] , tf , mode = 'wb', filesize_fun = 'unzip_verify' )
 
 			unzipped_files <- unzip_warn_fail( tf , exdir = paste0( tempdir() , '/unzips' ) )
 
 			# ..and read that text file directly into an R data.frame
 			# using the sas importation script downloaded before this big fat loop
-			x <- read_SAScii( unzipped_files , input )
+			# the encoding is specified here to avoid errors with string functions when removing comments
+			# from SAS code. Since comments do not need to be readable, we don't need to know which encoding
+			# the original PME data is in.
+			x <- read_SAScii( unzipped_files , input, filesize_fun = 'unzip_verify', encoding = 'latin1' )
 			
 			# convert all column names to lowercase
 			names( x ) <- tolower( names( x ) )

--- a/R/sascii.R
+++ b/R/sascii.R
@@ -2,7 +2,7 @@
 
 
 read_SAScii <-
-	function( dat_path , sas_path = NULL , beginline = 1 , lrecl = NULL , skip_decimal_division = NULL , zipped = FALSE , na_values = c( "NA" , "" , "." ) , sas_stru = NULL , sas_encoding = "windows-1252" , filesize_fun = 'httr' , ... ){
+	function( dat_path , sas_path = NULL , beginline = 1 , lrecl = NULL , skip_decimal_division = NULL , zipped = FALSE , na_values = c( "NA" , "" , "." ) , sas_stru = NULL , sas_encoding = "windows-1252" , filesize_fun = 'httr' , encoding = NULL, ... ){
 
 		if( is.null( sas_path ) & is.null( sas_stru ) ) stop( "either sas_path= or sas_stru= must be specified" )
 		if( !is.null( sas_path ) & !is.null( sas_stru ) ) stop( "either sas_path= or sas_stru= must be specified, but not both" )
@@ -13,7 +13,7 @@ read_SAScii <-
 			close( this_con )
 			tf <- tempfile()
 			writeLines( this_sas , tf )
-			suppressWarnings( sasc <- SAScii::parse.SAScii( tf , beginline = beginline , lrecl = lrecl ) )
+			suppressWarnings( sasc <- SAScii::parse.SAScii( tf , beginline = beginline , lrecl = lrecl, encoding = encoding ) )
 		} else sasc <- sas_stru
 			
 		y <- sasc[ !is.na( sasc[ , "varname" ] ) , ]


### PR DESCRIPTION
This is one of two pull requests I'm making to make the lodown package run for the Pesquisa Mensal de Emprego (PME). Changes are as follows: 

1. Switch from using `httr` to using `unzip_verify` as the `filesize_fun` argument in calls to `cachaca()` in `pme.R`. When using `httr`, I was encountering errors, which I believe is related to the `httr` packages' lack of support for FTP. 
2. Allow the SAS parser in `read_SAScii` to accept an `encoding` argument, which will convert SAS code to an encoding of the user's choice. This allows the SAS parser to parse SAS code that is written in encodings other than UTF-8 (the SAS code that is provided with PME's documentation is not in UTF-8). 

Please note that I'm not an expert on the technical details of this stuff and made these changes to get lodown running for me in as short a time as possible. I hope these changes will be helpful to other users too, but they may well have limitations I haven't explored.

Edit: see the second pull request [here](https://github.com/ajdamico/SAScii/pull/7).