### PR TITLE
Fix NHANES download

### DIFF
--- a/R/lodown.R
+++ b/R/lodown.R
@@ -38,7 +38,7 @@ lodown <-
 
 		if( nrow( catalog ) == 0 ) stop( "catalog must have at least one record" )
 
-		unique_directories <- unique( c( if( 'unzip_folder' %in% names( catalog ) ) catalog$unzip_folder , if( 'output_filename' %in% names( catalog ) ) np_dirname( catalog$output_filename ) , if( 'dbfile' %in% names( catalog ) ) np_dirname( catalog$dbfile ) ,  if( 'output_folder' %in% names( catalog ) ) catalog$output_folder ) )
+		unique_directories <- unique( c( if( 'unzip_folder' %in% names( catalog ) )catalog$unzip_folder , if( 'output_filename' %in% names( catalog ) ) np_dirname( catalog$output_filename ) , if( 'dbfile' %in% names( catalog ) ) np_dirname( catalog$dbfile ) , if( 'output_folder' %in% names( catalog ) ) catalog$output_folder ) )
 
 		for ( this_dir in unique_directories ){
 			if( !dir.exists( this_dir ) ){

--- a/R/lodown.R
+++ b/R/lodown.R
@@ -35,52 +35,52 @@ lodown <-
 	function( data_name , catalog = NULL , ... ){
 
 		if( is.null( catalog ) ) catalog <- get_catalog( data_name , ... )
-		
+
 		if( nrow( catalog ) == 0 ) stop( "catalog must have at least one record" )
 
-		unique_directories <- unique( c( catalog$unzip_folder , if( 'output_filename' %in% names( catalog ) ) np_dirname( catalog$output_filename ) , if( 'dbfile' %in% names( catalog ) ) np_dirname( catalog$dbfile ) , catalog$output_folder ) )
+		unique_directories <- unique( c( if( 'unzip_folder' %in% names( catalog ) ) catalog$unzip_folder , if( 'output_filename' %in% names( catalog ) ) np_dirname( catalog$output_filename ) , if( 'dbfile' %in% names( catalog ) ) np_dirname( catalog$dbfile ) ,  if( 'output_folder' %in% names( catalog ) ) catalog$output_folder ) )
 
 		for ( this_dir in unique_directories ){
 			if( !dir.exists( this_dir ) ){
-				tryCatch( { 
-					dir.create( this_dir , recursive = TRUE , showWarnings = TRUE ) 
-					} , 
-					warning = function( w ) stop( "while creating directory " , this_dir , "\n" , conditionMessage( w ) ) 
+				tryCatch( {
+					dir.create( this_dir , recursive = TRUE , showWarnings = TRUE )
+					} ,
+					warning = function( w ) stop( "while creating directory " , this_dir , "\n" , conditionMessage( w ) )
 				)
 			}
 		}
 
-		catalog$case_count <- NA
-		
+		catalog$case_count <- NA_integer_
+
 		load_fun <- getFromNamespace( paste0( "lodown_" , data_name ) , "lodown" )
 
 		cat( paste0( "locally downloading " , data_name , "\r\n\n" ) )
 
 		memory_note <- "\r\n\nlodown is now exiting due to a memory error.\nwindows users: your computing performance would suffer due to disk paging,\nbut you can increase your memory limits with beyond your available hardware with the `?memory.limit` function.\nfor example, you can set the memory ceiling of an R session to 256 GB by typing `memory.limit(256000)`.\r\n\n"
-		
+
 		installation_note <- "\r\n\nlodown is now exiting due to an installation error.\r\n\n"
-		
+
 		parameter_note <- "\r\n\nlodown is now exiting due to a parameter omission.\r\n\n"
-		
+
 		unknown_error_note <- "\r\n\nlodown is now exiting unexpectedly.\nwebsites that host publicly-downloadable microdata change often and sometimes those changes cause this software to break.\nif the error call stack below appears to be a hiccup in your internet connection, then please verify your connectivity and retry the download.\notherwise, please open a new issue at `https://github.com/ajdamico/asdfree/issues` with the contents of this error call stack and also the output of your `sessionInfo()`.\r\n\n"
-		
+
 		withCallingHandlers(
-			catalog <- load_fun( data_name = data_name , catalog , ... ) , 
-			error = 
-				function( e ){ 
-			
+			catalog <- load_fun( data_name = data_name , catalog , ... ) ,
+			error =
+				function( e ){
+
 					print( sessionInfo() )
-			
-					if( grepl( 'cannot allocate vector of size' , e ) ) message( memory_note ) else 
+
+					if( grepl( 'cannot allocate vector of size' , e ) ) message( memory_note ) else
 					if( grepl( 'parameter must be specified' , e ) ) message( parameter_note ) else
 					if( grepl( 'to install' , e ) ) message( installation_note ) else {
-					
+
 						message( unknown_error_note )
-					
+
 						print( sys.calls() )
-						
+
 					}
-					
+
 				}
 		)
 
@@ -89,12 +89,12 @@ lodown <-
 		invisible( catalog )
 
 	}
-	
+
 no.na <- function( x , value = FALSE ){ x[ is.na( x ) ] <- value ; x }
 
 unzip_warn_fail <- function( ... ) tryCatch( { unzip( ... ) } , warning = function( w ) stop( conditionMessage( w ) ) )
 
-unarchive_nicely <- 
+unarchive_nicely <-
 	function( file_to_unzip , unzip_directory = tempdir() ) {
 		file.remove( list.files( file.path( unzip_directory , "archive_unzip" ) , recursive = TRUE , full.names = TRUE ) )
 		archive::archive_extract( file_to_unzip , dir = file.path( unzip_directory , "archive_unzip" ) )

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -2,33 +2,33 @@ get_catalog_nhanes <-
 	function( data_name = "nhanes" , output_dir , ... ){
 
 		data_page <- "https://wwwn.cdc.gov/nchs/nhanes/search/DataPage.aspx"
-		
+
 		data_html <- xml2::read_html( data_page )
-		
+
 		this_table <- rvest::html_table( data_html )[[1]]
-	
+
 		names( this_table ) <- c( 'years' , 'data_name' , 'doc_name' , 'file_name' , 'date_published' )
 
-		
+
 		all_links <- rvest::html_nodes( data_html , "a" )
-		
+
 		link_text <- rvest::html_text( all_links )
-		
+
 		link_refs <- rvest::html_attr( all_links , "href" )
-		
+
 		this_table$full_url <- link_refs[ match( this_table$file_name , link_text ) ]
 
 		this_table$doc_url <- link_refs[ match( this_table$doc_name , link_text ) ]
 
 		this_table[ c( 'full_url' , 'doc_url' ) ] <- sapply( this_table[ c( 'full_url' , 'doc_url' ) ] , function( w ) ifelse( is.na( w ) , NA , paste0( "https://wwwn.cdc.gov" , w ) ) )
-		
+
 		catalog <- this_table[ this_table$file_name != 'RDC Only' & this_table$date_published != 'Withdrawn' & this_table$full_url != "https://wwwn.cdc.gov#" , ]
 
 		# one all years doc hardcode
 		ayd <- catalog[ tolower( catalog$full_url ) == "https://wwwn.cdc.gov/nchs/nhanes/dxa/dxa.aspx" , ]
-		
+
 		ayd$years <- ayd$full_url <- ayd$doc_url <- NULL
-		
+
 		this_ayd <-
 			data.frame(
 				years = c( "2005-2006" , "2003-2004" , "2001-2002" , "1999-2000" ) ,
@@ -36,17 +36,17 @@ get_catalog_nhanes <-
 				doc_url = paste0( "https://wwwn.cdc.gov/Nchs/Nhanes/2005-2006/DXX_D.htm" , "https://wwwn.cdc.gov/Nchs/Data/Nhanes/Dxa/dxx_c.pdf" , "https://wwwn.cdc.gov/Nchs/Data/Nhanes/Dxa/dxx_b.pdf" , "https://wwwn.cdc.gov/Nchs/Data/Nhanes/Dxa/dxx.pdf" ) ,
 				stringsAsFactors = FALSE
 			)
-		
+
 		ayd <- merge( ayd , this_ayd )
-		
+
 		catalog <- catalog[ tolower( catalog$full_url ) != "https://wwwn.cdc.gov/nchs/nhanes/dxa/dxa.aspx" , ]
-		
+
 		catalog <- rbind( catalog , ayd )
 
 		catalog$output_filename <- paste0( output_dir , "/" , catalog$years , "/" , tolower( gsub( "\\.xpt" , ".rds" , basename( catalog$full_url ) , ignore.case = TRUE ) ) )
-		
+
 		catalog <- catalog[ order( catalog[ , 'years' ] ) , ]
-		
+
 		catalog
 
 	}
@@ -60,31 +60,30 @@ lodown_nhanes <-
 		tf <- tempfile()
 
 		for ( i in seq_len( nrow( catalog ) ) ){
-
 			# download the file
-			cachaca( catalog[ i , "full_url" ] , tf , mode = 'wb' )
+			cachaca( catalog[[ i , "full_url" ]] , tf , mode = 'wb' )
 
-			if( grepl( "\\.zip$" , catalog[ i , "full_url" ] , ignore.case = TRUE ) ){
-				
+			if( grepl( "\\.zip$" , catalog[[ i , "full_url" ]] , ignore.case = TRUE ) ){
+
 				unzipped_files <- unzip( tf , exdir = tempdir() )
-				
+
 				suppressWarnings( file.remove( tf ) )
-				
+
 				tf <- unzipped_files
 
 			}
-			
+
 			xport_attempt <- try( x <- foreign::read.xport( tf ) , silent = TRUE )
-			
+
 			if( class( xport_attempt ) == 'try-error' ) x <- data.frame( haven::read_sas( tf ) )
 
 			# convert all column names to lowercase
 			names( x ) <- tolower( names( x ) )
 
-			saveRDS( x , file = catalog[ i , 'output_filename' ] , compress = FALSE )
+			saveRDS( x , file = catalog[[ i , 'output_filename' ]] , compress = FALSE )
 
 			catalog[ i , 'case_count' ] <- nrow( x )
-			
+
 			# delete the temporary files
 			suppressWarnings( file.remove( tf ) )
 
@@ -93,7 +92,7 @@ lodown_nhanes <-
 		}
 
 		on.exit()
-		
+
 		catalog
 
 	}

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -47,6 +47,8 @@ get_catalog_nhanes <-
 
 		catalog <- catalog[ order( catalog[ , 'years' ] ) , ]
 
+		catalog <- data.frame(catalog)
+
 		catalog
 
 	}
@@ -60,10 +62,11 @@ lodown_nhanes <-
 		tf <- tempfile()
 
 		for ( i in seq_len( nrow( catalog ) ) ){
-			# download the file
-			cachaca( catalog[[ i , "full_url" ]] , tf , mode = 'wb' )
 
-			if( grepl( "\\.zip$" , catalog[[ i , "full_url" ]] , ignore.case = TRUE ) ){
+			# download the file
+			cachaca( catalog[ i , "full_url" ] , tf , mode = 'wb' )
+
+			if( grepl( "\\.zip$" , catalog[ i , "full_url" ] , ignore.case = TRUE ) ){
 
 				unzipped_files <- unzip( tf , exdir = tempdir() )
 
@@ -80,7 +83,7 @@ lodown_nhanes <-
 			# convert all column names to lowercase
 			names( x ) <- tolower( names( x ) )
 
-			saveRDS( x , file = catalog[[ i , 'output_filename' ]] , compress = FALSE )
+			saveRDS( x , file = catalog[ i , 'output_filename' ] , compress = FALSE )
 
 			catalog[ i , 'case_count' ] <- nrow( x )
 


### PR DESCRIPTION
This PR fixes ajdamico/asdfree#357 and a couple of related errors/warnings.

Specifically, inside `lodown_nhanes()`, there were a couple of download errors because catalog is a tibble, which retains type when subset with single []. This led to the URL and then also the filename not being processed correctly, so that I replaced it by [[]]

In `lodown()`, I changed the default value of `case_count` from NA to NA_integer_. This is because a column of all NAs in a tibble gets the type logical, so that `catalog[ i , 'case_count' ] <- nrow( x )` in `lodown_nhanes()` failed with a type conversion error prior to that change. Similarly, tibbles issue warnings when you try to access columns that don't exist, so that I added to `if` clauses to the code that creates the `unique_directories`. 

I hope that all makes sense - please let me know if anything is unclear.